### PR TITLE
Add places-autocomplete service in app to fix unit tests

### DIFF
--- a/app/services/places-autocomplete.js
+++ b/app/services/places-autocomplete.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-places-autocomplete/services/places-autocomplete';


### PR DESCRIPTION
Hey Taras,
Great talk last night. 

Not sure if you intended to remove the service exported in 'app' and thus hide it from the consuming app, but since it breaks unit tests, I thought we should add it back.
:)  
--Miguel
